### PR TITLE
Import custom configuration in slice test

### DIFF
--- a/src/main/java/com/example/demo/config/WebserviceConfiguration.java
+++ b/src/main/java/com/example/demo/config/WebserviceConfiguration.java
@@ -1,28 +1,16 @@
 package com.example.demo.config;
 
 import org.apache.wss4j.common.ConfigurationConstants;
-import org.springframework.boot.web.servlet.ServletRegistrationBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.ws.config.annotation.EnableWs;
 import org.springframework.ws.soap.security.wss4j2.Wss4jSecurityInterceptor;
 import org.springframework.ws.soap.security.wss4j2.callback.SimplePasswordValidationCallbackHandler;
 import org.springframework.ws.soap.server.endpoint.interceptor.DelegatingSmartSoapEndpointInterceptor;
-import org.springframework.ws.transport.http.MessageDispatcherServlet;
 
 import java.util.Map;
 
 @Configuration
-@EnableWs
 public class WebserviceConfiguration {
-
-    @Bean
-    public ServletRegistrationBean<MessageDispatcherServlet> servlet(ApplicationContext context) {
-        MessageDispatcherServlet servlet = new MessageDispatcherServlet();
-        servlet.setApplicationContext(context);
-        return new ServletRegistrationBean<>(servlet, "/ws/*");
-    }
 
     @Bean
     public Wss4jSecurityInterceptor securityInterceptor(SimplePasswordValidationCallbackHandler callbackHandler) {

--- a/src/test/java/com/example/demo/endpoint/HelloWorldEndpointTest.java
+++ b/src/test/java/com/example/demo/endpoint/HelloWorldEndpointTest.java
@@ -1,9 +1,11 @@
 package com.example.demo.endpoint;
 
+import com.example.demo.config.WebserviceConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.webservices.server.WebServiceServerTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
 import org.springframework.ws.soap.security.wss4j2.Wss4jSecurityInterceptor;
 import org.springframework.ws.test.server.MockWebServiceClient;
 import org.springframework.xml.transform.StringSource;
@@ -12,8 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.ws.test.server.RequestCreators.withSoapEnvelope;
 import static org.springframework.ws.test.server.ResponseMatchers.payload;
 
-// All the tests fail, because interceptors are not present in the application context
-@WebServiceServerTest(HelloWorldEndpoint.class)
+@WebServiceServerTest
+@Import(WebserviceConfiguration.class)
 class HelloWorldEndpointTest {
 
     @Autowired


### PR DESCRIPTION
Your configuration class should neither require `@EnableWs`, nor a `MessageDispatcherServlet` as it is configured automatically by `@WebServiceServerTest`.

With that change, the only thing that remains in the configuration class is your custom endpoint interceptors (good!) so you can import them as I've done in this commit.

If those 3 beans where `@Component` then the slice test would have scanned them (because they implement `EndpointInterceptor`).